### PR TITLE
add error handling to FitbitClient::Network::Request parse_response

### DIFF
--- a/lib/fitbit_client/network/request.rb
+++ b/lib/fitbit_client/network/request.rb
@@ -62,7 +62,11 @@ module FitbitClient
 
       def parse_response(response)
         return {} if response.nil? || response.body.nil? || response.body.empty?
-        JSON.parse response.body
+        begin
+          JSON.parse response.body
+        rescue JSON::ParserError => e
+          raise FitbitClient::Error.new('JSON::ParserError when parsing response', response)
+        end
       end
 
       def check_unrecoverable_token(parsed_response, error)


### PR DESCRIPTION
this change handles an intermittent and recurring `JSON::ParserError`. users can then rescue `FitbitClient::Error` and log `error.to_s` to get more detailed information on error.