### PR TITLE
handle failed response in parse response

### DIFF
--- a/lib/fitbit_client/network/request.rb
+++ b/lib/fitbit_client/network/request.rb
@@ -65,7 +65,7 @@ module FitbitClient
         if response.status == 200
           JSON.parse response.body
         else
-          raise FitbitClient::Error.new('JSON::ParserError when parsing response', response)
+          raise FitbitClient::Error.new('Fitbit request unsuccessful', response)
         end
       end
 

--- a/lib/fitbit_client/network/request.rb
+++ b/lib/fitbit_client/network/request.rb
@@ -62,7 +62,11 @@ module FitbitClient
 
       def parse_response(response)
         return {} if response.nil? || response.body.nil? || response.body.empty?
-        JSON.parse response.body
+        if response.status == 200
+          JSON.parse response.body
+        else
+          raise FitbitClient::Error.new('JSON::ParserError when parsing response', response)
+        end
       end
 
       def check_unrecoverable_token(parsed_response, error)


### PR DESCRIPTION
this change will raise a `Fitbit::Client` error if the response received by `parse_response` is not a success.